### PR TITLE
Side panel style changes and auto sizing

### DIFF
--- a/map/map.css
+++ b/map/map.css
@@ -3,33 +3,54 @@ body {
 	margin: 0;
 }
 
-html,
-body,
-#map {
-	height: 100%;
-	width: 100%;
+html, body, #map {
+  height: 100%;
+  width: 100%;
+  --contentwidth: 40vw; /* var = 40% of viewport width. */
 }
 
 .sidepanel {
   height: 100%;
-  width: 40%;
+  width: 0%;
   position: fixed;
   z-index: 1001; /*Places side over map*/
   top: 0;
+  bottom: 0;
   left: 0;
   background-color: rgb(191, 201, 205);
   overflow-x: hidden;
+  overflow-y: scroll;
   transition: 0.5s;
-  padding-top: 60px;
 }
 
 .sidepanel a {
   padding: 8px 8px 8px 32px;
   text-decoration: none;
+  text-shadow: -1px 0 #000000, 0 1px #000000, 1px 0 #000000, 0 -1px #000000;
   font-size: 25px;
-  color: #282929;
+  color: #ffffff;
   display: block;
   transition: 0.3s;
+  z-index: 1002; 
+}
+
+.sidepanel #sidecontent {
+  position: absolute;
+  display: inline-block;
+  width: var(--contentwidth)
+}
+
+.sidepanel #sidecontent img {
+  max-width: var(--contentwidth);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.sidepanel #sidecontent div {
+  position: absolute;
+  width: var(--contentwidth);
+  padding: 30px 30px;
+  box-sizing: border-box;
 }
 
 .sidepanel .closebtn {

--- a/map/map.html
+++ b/map/map.html
@@ -27,6 +27,6 @@
 		</div>
 		<!--Attach map element, then import map script.-->
 		<div id="map"></div>
-		<script src="./map.js"></script>
+		<script src="map.js"></script>
 	</body>
 </html>

--- a/map/map.js
+++ b/map/map.js
@@ -16,8 +16,6 @@ L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
 
 // Initialize location to PSU Campus
 map.setView(L.latLng(45.51,-122.68), 16)
-// hide side panel at startup
-document.getElementById("mySide").hidden = true;
 
 
 /*
@@ -53,15 +51,18 @@ These are the marker locations and content associated with them.
 const locations = [
 	{
 		position: [45.51, -122.68],
-		content: `<img src='media/TEMP/dui-food-serving-vessel.jpg' width='300' height:'300'>`,
+		content: `<img src='media/TEMP/dui-food-serving-vessel.jpg'>
+		<div>The cat (Felis catus), commonly referred to as the domestic cat or house cat, is a small domesticated carnivorous mammal. It is the only domesticated species of the family Felidae. Recent advances in archaeology and genetics have shown that the domestication of the cat occurred in the Near East around 7500 BC. It is commonly kept as a house pet and farm cat, but also ranges freely as a feral cat avoiding human contact. It is valued by humans for companionship and its ability to kill vermin. Its retractable claws are adapted to killing small prey like mice and rats. It has a strong, flexible body, quick reflexes, sharp teeth, and its night vision and sense of smell are well developed. It is a social species, but a solitary hunter and a crepuscular predator. Cat communication includes vocalizations like meowing, purring, trilling, hissing, growling, and grunting as well as cat body language. It can hear sounds too faint or too high in frequency for human ears, such as those made by small mammals. It secretes and perceives pheromones.</div>`,
 	},
 	{
 		position: [45.51, -122.685],
-		content: `<img src='media/TEMP/hu-wine-container.jpg' width='300' height:'300'>`,
+		content: `<img src='media/TEMP/hu-wine-container.jpg'>
+		<div>The cat (Felis catus), commonly referred to as the domestic cat or house cat, is a small domesticated carnivorous mammal. It is the only domesticated species of the family Felidae. Recent advances in archaeology and genetics have shown that the domestication of the cat occurred in the Near East around 7500 BC. It is commonly kept as a house pet and farm cat, but also ranges freely as a feral cat avoiding human contact. It is valued by humans for companionship and its ability to kill vermin. Its retractable claws are adapted to killing small prey like mice and rats. It has a strong, flexible body, quick reflexes, sharp teeth, and its night vision and sense of smell are well developed. It is a social species, but a solitary hunter and a crepuscular predator. Cat communication includes vocalizations like meowing, purring, trilling, hissing, growling, and grunting as well as cat body language. It can hear sounds too faint or too high in frequency for human ears, such as those made by small mammals. It secretes and perceives pheromones.</div>`,
 	},
 	{
 		position: [45.515, -122.685],
-		content: `<img src='media/TEMP/chicken.jpg' width='500' height='500'>`,
+		content: `<img src='media/TEMP/chicken.jpg'>
+		<div>The cat (Felis catus), commonly referred to as the domestic cat or house cat, is a small domesticated carnivorous mammal. It is the only domesticated species of the family Felidae. Recent advances in archaeology and genetics have shown that the domestication of the cat occurred in the Near East around 7500 BC. It is commonly kept as a house pet and farm cat, but also ranges freely as a feral cat avoiding human contact. It is valued by humans for companionship and its ability to kill vermin. Its retractable claws are adapted to killing small prey like mice and rats. It has a strong, flexible body, quick reflexes, sharp teeth, and its night vision and sense of smell are well developed. It is a social species, but a solitary hunter and a crepuscular predator. Cat communication includes vocalizations like meowing, purring, trilling, hissing, growling, and grunting as well as cat body language. It can hear sounds too faint or too high in frequency for human ears, such as those made by small mammals. It secretes and perceives pheromones.</div>`,
 	},
 ];
 
@@ -81,13 +82,16 @@ These handle onclick actions for the sidebar.
 */
 function openside(content) {
 	//Reveal side panel.
-	document.getElementById("mySide").hidden = false;
+	document.getElementById("mySide").style.width = "40%";
 	document.getElementById("sidecontent").innerHTML = content;
 }
 
 // called by button in map.html
 function closeside() {
 	//Hide side panel.
+	document.getElementById("mySide").style.width = "0%";
+	
+	//This prevents the panel from removing content before sliding panel was gone.
+	sleep(0.5);
 	document.getElementById("sidecontent").innerHTML = "";
-	document.getElementById("mySide").hidden = true;
 }


### PR DESCRIPTION
I feel like I've accomplished nothing, but it still took a couple days of work. HTML and CSS is wack.

Here's some changes in the order I did them: 

- Undid Ash's hidden elements.
- The example location content now includes a lot of text from Wikipedia's page on cats. 
- The content of the side panel doesn't disappear before the panel actually closes.
- Img and div elements are now automicatically sized up to 40% of the page's size, matching the maximum size of the side panel is. Very convenient. 
  - This also means that we won't get textboxes and images changing sizes because their sizes are locked in. 
- There was also a bug with the 'x' to close the side panel, so the 'x' no longer gets space to itself and 'sits on top' of the side panel's content.
  - Added text shadow to make the 'x' easier to see because it liked getting lost. Also our side panel now scrolls. Neat.

Anyone can feel free to change the colors and padding sizes. Don't you dare touch width and height.

![Screenshot 2024-05-23 191411](https://github.com/Ahmadsafa21/Interactive-map-web-app/assets/147555792/b20677ff-e793-4286-89f1-5a777c01b43e)
