### PR TITLE
Gss23 mobilepanel2.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,8 @@
       integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
       crossorigin=""
     ></script>
-    <link rel="stylesheet" href="map/map.css" />
+    <link rel="stylesheet" href="style/map.css" />
+    <link rel="stylesheet" href="style/navbar.css" />
 
     <!--Navigation bar-->
     <nav>

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
   </head>
   <body>
     <!--Doesn't matter where this div goes.-->
-    <div id="mySide" class="sidepanel">
+    <div id="mapSide" class="sidepanel">
       <a href="javascript:void(0)" class="closebtn" onclick="closeside()"
         >&times;</a
       >

--- a/map/map.css
+++ b/map/map.css
@@ -124,6 +124,18 @@ nav {
     overflow-x: hidden;
   }
 
+  html, body, #map {
+    --contentwidth: 100vw;
+  }
+
+  .sidepanel #sidecontent div {
+    width: var(--contentwidth);
+  }
+
+  .sidepanel #sidecontent img {
+    max-width: var(--contentwidth);
+  }
+
   .nav-links {
     position: absolute;
     right: 0;

--- a/map/map.js
+++ b/map/map.js
@@ -78,9 +78,6 @@ locations.forEach(({ position, content }) => {
 These handle onclick actions for the sidebar.
 */
 function openside(content) {
-	//Reveal side panel.
-	document.getElementById("mapSide").style.width = "40%";
-
 	//Checks screensize and call changewidth.
 	var x = matchMedia("(max-width: 768px)");
 	changeWidth(x);

--- a/map/map.js
+++ b/map/map.js
@@ -78,19 +78,43 @@ locations.forEach(({ position, content }) => {
 These handle onclick actions for the sidebar.
 */
 function openside(content) {
-  //Reveal side panel.
-  document.getElementById("mySide").style.width = "40%";
-  document.getElementById("sidecontent").innerHTML = content;
+	//Reveal side panel.
+	document.getElementById("mapSide").style.width = "40%";
+
+	//Checks screensize and call changewidth.
+	var x = matchMedia("(max-width: 768px)");
+	changeWidth(x);
+	
+	//If user changes screensize while sidepanel is open.
+	x.addEventListener("change", function() {
+		if (document.getElementById("mapSide").style.width != "0%") {
+			changeWidth(x);
+		}
+	})
+	
+	//Assigns sidepanel content.
+	document.getElementById("sidecontent").innerHTML = content;
 }
 
-// called by button in map.html
+//Called by button in index.html and handles the closing of the button.
 function closeside() {
-  //Hide side panel.
-  document.getElementById("mySide").style.width = "0%";
+	//Hide side panel.
+	document.getElementById("mapSide").style.width = "0%";
+	
+	//Prevents the panel from removing content before sliding panel was gone.
+	sleep(0.5);
 
-  //This prevents the panel from removing content before sliding panel was gone.
-  sleep(0.5);
-  document.getElementById("sidecontent").innerHTML = "";
+	//Empties sidepanel content.
+	document.getElementById("sidecontent").innerHTML = "";
+}
+
+//Called by openside to change the width of the side panel depending on screen size.
+function changeWidth (x) {
+	if (x.matches) {	//If screensize < 768px
+		document.getElementById("mapSide").style.width = "100%";
+	} else {
+		document.getElementById("mapSide").style.width = "40%";
+	}
 }
 
 //Navigation bar

--- a/style/map.css
+++ b/style/map.css
@@ -1,0 +1,77 @@
+html, body {
+  padding: 0;
+  margin: 0;
+}
+
+html, body, #map {
+  height: 100%;
+  width: 100%;
+  --contentwidth: 40vw; /* var = 40% of viewport width. */
+}
+
+.sidepanel {
+  height: 100%;
+  width: 0%;
+  position: fixed;
+  z-index: 1001; /*Places side over map*/
+  top: 0;
+  bottom: 0;
+  left: 0;
+  background-color: rgb(191, 201, 205);
+  overflow-x: hidden;
+  overflow-y: scroll;
+  transition: 0.5s;
+}
+
+.sidepanel a {
+  padding: 8px 8px 8px 32px;
+  position: fixed;
+  text-decoration: none;
+  text-shadow: -1px 0 #000000, 0 1px #000000, 1px 0 #000000, 0 -1px #000000;
+  font-size: 25px;
+  color: #ffffff;
+  display: block;
+  transition: 0.3s;
+  z-index: 1002;
+}
+
+.sidepanel #sidecontent {
+  position: absolute;
+  display: inline-block;
+  width: var(--contentwidth);
+}
+
+.sidepanel #sidecontent img {
+  max-width: var(--contentwidth);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.sidepanel #sidecontent div {
+  position: absolute;
+  width: var(--contentwidth);
+  padding: 30px 30px;
+  box-sizing: border-box;
+}
+
+.sidepanel .closebtn {
+  position: absolute;
+  top: 0;
+  right: 25px;
+  font-size: 36px;
+  margin-left: 50px;
+}
+
+@media screen and (max-width: 768px) {
+  html, body, #map {
+    --contentwidth: 100vw;
+  }
+
+  .sidepanel #sidecontent div {
+    width: var(--contentwidth);
+  }
+
+  .sidepanel #sidecontent img {
+    max-width: var(--contentwidth);
+  }
+}

--- a/style/navbar.css
+++ b/style/navbar.css
@@ -1,68 +1,3 @@
-body {
-  padding: 0;
-  margin: 0;
-}
-
-html,
-body,
-#map {
-  height: 100%;
-  width: 100%;
-  --contentwidth: 40vw; /* var = 40% of viewport width. */
-}
-
-.sidepanel {
-  height: 100%;
-  width: 0%;
-  position: fixed;
-  z-index: 1001; /*Places side over map*/
-  top: 0;
-  bottom: 0;
-  left: 0;
-  background-color: rgb(191, 201, 205);
-  overflow-x: hidden;
-  overflow-y: scroll;
-  transition: 0.5s;
-}
-
-.sidepanel a {
-  padding: 8px 8px 8px 32px;
-  text-decoration: none;
-  text-shadow: -1px 0 #000000, 0 1px #000000, 1px 0 #000000, 0 -1px #000000;
-  font-size: 25px;
-  color: #ffffff;
-  display: block;
-  transition: 0.3s;
-  z-index: 1002;
-}
-
-.sidepanel #sidecontent {
-  position: absolute;
-  display: inline-block;
-  width: var(--contentwidth);
-}
-
-.sidepanel #sidecontent img {
-  max-width: var(--contentwidth);
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.sidepanel #sidecontent div {
-  position: absolute;
-  width: var(--contentwidth);
-  padding: 30px 30px;
-  box-sizing: border-box;
-}
-
-.sidepanel .closebtn {
-  position: absolute;
-  top: 0;
-  right: 25px;
-  font-size: 36px;
-  margin-left: 50px;
-}
-
 /* navigation bar */
 nav {
   display: flex;
@@ -122,18 +57,6 @@ nav {
 @media screen and (max-width: 768px) {
   body {
     overflow-x: hidden;
-  }
-
-  html, body, #map {
-    --contentwidth: 100vw;
-  }
-
-  .sidepanel #sidecontent div {
-    width: var(--contentwidth);
-  }
-
-  .sidepanel #sidecontent img {
-    max-width: var(--contentwidth);
   }
 
   .nav-links {


### PR DESCRIPTION
Only a few changes. In order:
- Created a new folder called style. This should be used to contain stylesheets (CSS).
- Moved map.css into this new folder.
- Split Yuki's navbar stylesheets into a new file called navbar.css
- Added some CSS/JavaScript that makes the panel more mobile-friendly. 
   - The panel now takes up the entire width on smaller screens.
   - Added a new function and event listener that checks the screen size and responds accordingly.


A handful of bugs have been found, mostly concerning the new navbar and its interaction with the map/side panel. 
- The burger menu isn't hidden or shrunk. Instead, it moves to the right and off the screen.
  - This changes the width of the screen. This means the 'x' to close the side panel is hidden from the user, there's an awkward horizontal scroll, and the map credits are hidden.
- The nav bar 'pushes' down everything. This adds a scroll to the page where one isn't necessary.
  - This hides the bottom of the page, including the map credits.
  - Maybe we can create a container for the two of them? Not sure how to fix this yet.
- The side panel ignores the navbar and hides it.
  - I will work on tying the side panel height to the map height.
- The z-index of the top navbar is lower than the burger menu. This makes the 'x' to close the burger menu hard to click on some screens.