### PR TITLE
Gss23 sidepanel smallfixes

### DIFF
--- a/map/map.js
+++ b/map/map.js
@@ -5,7 +5,7 @@ const USER_LOCATION = false; // ask user for location on start
 /*
 This section creates the map.
 */
-var map = L.map("map").fitWorld();
+var map = L.map("map", {zoomControl: false}).fitWorld();
 
 //Can use other maps.
 L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
@@ -13,8 +13,12 @@ L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
   attribution: "© OpenStreetMap",
 }).addTo(map);
 
+L.control.zoom({
+	position: 'bottomright'
+}).addTo(map);
+
 // Initialize location to PSU Campus
-map.setView(L.latLng(45.51, -122.69), 16);
+map.setView(L.latLng(45.511477, -122.683545), 16);
 
 /*
 This section asks users for their location.

--- a/map/map.js
+++ b/map/map.js
@@ -53,29 +53,29 @@ const locations = [
   {
     // tree/marker
     position: [45.50990, -122.68458],
-    content: `<div>
-    <p><img src='media/accountability marker.jpg'><img src='media/memorial_tree.jpg'></p>
+    content: `<img src='media/accountability marker.jpg'>
+	<img src='media/memorial_tree.jpg'>
+	<div>
     <p>Washington Family Memorial Tree and PSU Accountability Marker</p>
     <p>Immediately following the shooting death of Jason Washington, the members of his family marked the spot on SW College Street near Broadway.  Jason had been on the ground near the tree on the south side of the street.  The family decorated the tree and made it a living memorial for the many, many people who pass on that street everyday, especially for the PSU Students who lived in the Broadway Building and whose back exit faces the tree.  The tree is sometimes adorned with holiday decorations that change with the seasons.  Family members also leave remembrances and messages for Jason attached to the tree.  The location, marked by the tree, has since 2018 served as a site for activism, marches, vigils and other commemorative events connected to Jason’s memory.</p>
     <p>Guided by family member Kayla Washington, the university’s memorial art committee created a permanent accountability marker at the location.  The marker states in very plain language the actions of PSU campus police that ended Jason Washington’s life on the night of June 29, 2018 as to leave no doubt as to how he died.  The marker also features a rendering of the tree, honoring the family’s dedication to memorializing their loved one.</p>
     <p><a href=https://www.pdx.edu/jason-washington-art-committee target='_blank'>Learn more about the Memorial Art Committee</a></p>
-    </div>`
+	</div>`
   },
   {
     // cheerful tortiose
     position: [45.51013, -122.68376],
-    content: `<div>
-    <p><img src='media/Cheerful_Tortoise.jpg'></p>
+    content: `<img src='media/Cheerful_Tortoise.jpg'>
+	<div>
     <p>The Cheerful Tortoise neighborhood pub has been a staple location for PSU students, faculty and staff since the mid-1960s.  Many threads of university history thread through the Cheerful Tortoise, from celebrations, meetings, and even the teaching of courses.  The Cheerful Tortoise figures in the story of Jason Washington’s life as it was the last establishment he and his friends visited before their fateful encounter with campus police on SW College Street just outside its door. </p>
     <p><a href=https://cheerfultortoise.com/ target='_blank'>Cheerful Tortoise's website</a></p>
-    
     </div>`
   },
   {
     //  millar library
     position: [45.51162, -122.68604],
-    content: `<div>
-    <p><img src='media/Special_Collections_Image.jpg'></p>
+    content: `<img src='media/Special_Collections_Image.jpg'>
+	<div>
     <audio controls>
       <source src="media/Special Collections Description for Interactive Map.mp3" type="audio/mpeg">
     Your browser does not support the audio element.
@@ -89,16 +89,16 @@ const locations = [
   {
     // SMSU mural
     position: [45.51190, -122.68426],
-    content: `<div>
-    <p><img src='media/Kyra_Watkins_Muralist.jpg'></p>
+    content: `<img src='media/Kyra_Watkins_Muralist.jpg'>
+	<div
     <p>Local muralist Kyra Watkins served as artist in residence during the academic year 2023-24. She was selected by the Washington family and the memorial committee to complete an artistic biographical remembrance of Jason for installation in the second floor mezzanine of the Smith Memorial Student Union on the Portland State University campus.  Kyra Watkins is a highly experienced muralist and an expert portraitist, truly gifted in rendering the face and expressiveness.  The mural measures 12 x 10 and its design was inspired by the artist’s many interactions with the Washington family during her residency as well as by numerous photos, videos, and remembrances of Jason in life.</p>
     </div>`
   },
   {
     // CPSO
     position: [45.51218, -122.68328],
-    content: `<div>
-    <p><img src='media/2024.05.23_CPSO_sign_3.jpeg'></p>
+    content: `<img src='media/2024.05.23_CPSO_sign_3.jpeg'>
+	<div>
     <p>Campus Public Safety Office</p>
     <p>From its ground-breaking in 1966, this building was called Koinonia House.  It was owned by Portland Campus Ministries, a consortium of eight different denominations that did outreach and service provision to the campus and the neighborhood.  In the 1970s, Koinonia housed services for military veterans and it has also served as classroom space.  PSU purchased the building in 2006, part of its long-term plan to grow eastward from the south park blocks in downtown and develop a “university district.”  Since 2012, the building has served as the campus public safety office.  In September, 2018, student activists camped in front of CPSO for two weeks in protest of the shooting of Jason Washington in June of that year.  Montgomery Street between SW Broadway and 6th Avenues was closed to traffic and turned into a pedestrian mall around 2019, and is the site of frequent events, gatherings, demonstrations, and other campus-related activities.</p>
     </div>`

--- a/map/map.js
+++ b/map/map.js
@@ -90,8 +90,10 @@ const locations = [
     // SMSU mural
     position: [45.51190, -122.68426],
     content: `<img src='media/Kyra_Watkins_Muralist.jpg'>
-	<div
+	<div>
     <p>Local muralist Kyra Watkins served as artist in residence during the academic year 2023-24. She was selected by the Washington family and the memorial committee to complete an artistic biographical remembrance of Jason for installation in the second floor mezzanine of the Smith Memorial Student Union on the Portland State University campus.  Kyra Watkins is a highly experienced muralist and an expert portraitist, truly gifted in rendering the face and expressiveness.  The mural measures 12 x 10 and its design was inspired by the artist’s many interactions with the Washington family during her residency as well as by numerous photos, videos, and remembrances of Jason in life.</p>
+	<a href='media/Kyra_Watkins_Interview.pdf'>Download Interview</a>
+	<embed src='media/Kyra_Watkins_Interview.pdf' type='application/pdf' class='responsive' width="100%" height="100%">
     </div>`
   },
   {
@@ -140,11 +142,8 @@ function closeside() {
 	//Hide side panel.
 	document.getElementById("mapSide").style.width = "0%";
 	
-	//Prevents the panel from removing content before sliding panel was gone.
-	sleep(0.5);
-
 	//Empties sidepanel content.
-	document.getElementById("sidecontent").innerHTML = "";
+	setTimeout(function() {document.getElementById("sidecontent").innerHTML = ""; }, 500)
 }
 
 //Called by openside to change the width of the side panel depending on screen size.
@@ -155,6 +154,7 @@ function changeWidth (x) {
 		document.getElementById("mapSide").style.width = "40%";
 	}
 }
+
 
 //Navigation bar
 const burger = document.querySelector(".burger");

--- a/style/map.css
+++ b/style/map.css
@@ -43,8 +43,8 @@ html, body, #map {
 
 .sidepanel #sidecontent img {
   max-width: var(--contentwidth);
-  margin-left: auto;
-  margin-right: auto;
+  margin: auto;
+  display: block;
 }
 
 .sidepanel #sidecontent div {

--- a/style/map.css
+++ b/style/map.css
@@ -17,22 +17,14 @@ html, body, #map {
   top: 0;
   bottom: 0;
   left: 0;
-  background-color: rgb(191, 201, 205);
+  background-color: #ffffff;
   overflow-x: hidden;
   overflow-y: scroll;
   transition: 0.5s;
 }
 
 .sidepanel a {
-  padding: 8px 8px 8px 32px;
-  position: fixed;
-  text-decoration: none;
-  text-shadow: -1px 0 #000000, 0 1px #000000, 1px 0 #000000, 0 -1px #000000;
-  font-size: 25px;
-  color: #ffffff;
   display: block;
-  transition: 0.3s;
-  z-index: 1002;
 }
 
 .sidepanel #sidecontent {
@@ -55,11 +47,16 @@ html, body, #map {
 }
 
 .sidepanel .closebtn {
-  position: absolute;
-  top: 0;
-  right: 25px;
-  font-size: 36px;
-  margin-left: 50px;
+  position: sticky;
+  text-align: right;
+  margin: -8px 5% -8px 85%;
+  top: -8px;
+  font-size: 44px;
+  text-decoration: none;
+  text-shadow: -1px 0 #000000, 0 1px #000000, 1px 0 #000000, 0 -1px #000000;
+  /*font-size: 25px;*/
+  color: #ffffff;
+  z-index: 1002;
 }
 
 @media screen and (max-width: 768px) {


### PR DESCRIPTION
What I did in order:
- Moved the zoom control from the top left (where it was displayed over the navbar) and grounded it to the bottom right corner, where it belongs.
- Modified our data/locations section so that the <img> tags are outside the <div> and centered the images (correctly this time). This was done because the <div> tag adds padding, hiding part of the image off the side panel. 
- Changed the color of the side panel to white.
- Made the side panel's 'x' sticky. It is always on the top right of the panel, even when you scroll down. This was Simon's suggestion. 
- Embedded the interview pdf, but poorly. It's hard to read, so I also added a download link for the interview.